### PR TITLE
enh(chore): integrate sonarQube dev edition on autodisco

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,8 @@
 properties([buildDiscarder(logRotator(numToKeepStr: '50'))])
 def serie = '21.04'
 def maintenanceBranch = "${serie}.x"
+env.PROJECT='centreon-awie'
+
 if (env.BRANCH_NAME.startsWith('release-')) {
   env.BUILD = 'RELEASE'
 } else if ((env.BRANCH_NAME == 'master') || (env.BRANCH_NAME == maintenanceBranch)) {
@@ -71,15 +73,27 @@ try {
           referenceJobName: 'centreon-awie/master'
         )
 
-        if ((env.BUILD == 'RELEASE') || (env.BUILD == 'REFERENCE')) {
-          withSonarQubeEnv('SonarQube') {
-            sh "./centreon-build/jobs/awie/${serie}/mon-awie-analysis.sh"
-          }
+        // Run sonarQube analysis
+        withSonarQubeEnv('SonarQubeDev') {
+          sh "./centreon-build/jobs/awie/${serie}/mon-awie-analysis.sh"
         }
       }
     }
     if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
       error('Unit tests stage failure.');
+    }
+  }
+
+  // sonarQube step to get qualityGate result
+  stage('Quality gate') {
+    timeout(time: 10, unit: 'MINUTES') {
+      def qualityGate = waitForQualityGate()
+      if (qualityGate.status != 'OK') {
+        currentBuild.result = 'FAIL'
+      }
+    }
+    if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
+      error('Quality gate failure: ${qualityGate.status}.');
     }
   }
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,12 @@
-sonar.projectKey=centreon-awie-21.04
-sonar.projectName=Centreon AWIE 21.04
-sonar.sources=.
+# project
+sonar.projectKey={PROJECT_TITLE}
+sonar.projectName={PROJECT_NAME}
+sonar.projectVersion={PROJECT_VERSION}
+sonar.sources=www
+
+#exclusions
+sonar.exclusions=   features/**/*,\
+                    doc/**/*,\
+
+sonar.coverage.exclusions=  libinstall/**/*,\
+                            packaging/**/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.sources=www
 
 #exclusions
 sonar.exclusions=   features/**/*,\
-                    doc/**/*,\
+                    doc/**/*
 
 sonar.coverage.exclusions=  libinstall/**/*,\
                             packaging/**/*


### PR DESCRIPTION
## Description

Transition from sonarQube community to dev edition 

**Fixes** # (MON-5609)
****Requires** https://github.com/centreon/centreon-build/pull/454**
![image](https://user-images.githubusercontent.com/34628915/111512834-77160f80-8750-11eb-8bfe-9691d49e3b80.png)


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

